### PR TITLE
Allow FD trinket swaps.

### DIFF
--- a/TrinketMenu/TrinketMenu.lua
+++ b/TrinketMenu/TrinketMenu.lua
@@ -334,7 +334,7 @@ end
 
 -- returns true if the player is really dead or ghost, not merely FD
 function TrinketMenu.IsPlayerReallyDead()
-	return UnitIsDeadOrGhost("player")
+	return UnitIsDeadOrGhost("player") and not UnitIsFeignDeath("player")
 end
 
 function TrinketMenu.ItemInfo(slot)

--- a/TrinketMenu/TrinketMenu.lua
+++ b/TrinketMenu/TrinketMenu.lua
@@ -334,7 +334,7 @@ end
 
 -- returns true if the player is really dead or ghost, not merely FD
 function TrinketMenu.IsPlayerReallyDead()
-	return UnitIsDeadOrGhost("player") and not UnitIsFeignDeath("player")
+	return IsClassic and (UnitIsDeadOrGhost("player") and not UnitIsFeignDeath("player")) or UnitIsDeadOrGhost("player")
 end
 
 function TrinketMenu.ItemInfo(slot)


### PR DESCRIPTION
As a hunter I'd like to swap queued up trinkets during an encounter with Feign Death. 

Instead of queuing the trinket when a player is dead, calling `IsPlayerReallyDead()` will also check if the player is using Feign Death and return `false` in that scenario.