### PR TITLE
fix: exact trinket name matching

### DIFF
--- a/TrinketMenu.lua
+++ b/TrinketMenu.lua
@@ -415,14 +415,18 @@ end
 function TrinketMenu.FindItem(name, includeInventory)
 	if includeInventory then
 		for i = 13, 14 do
-			if string.find(GetInventoryItemLink("player", i) or "", name, 1, true) then
+			local itemLink = GetInventoryItemLink("player", i) or ""
+			local itemName = GetItemInfo(itemLink)
+			if itemName == name then
 				return i
 			end
 		end
 	end
 	for i = 0, 4 do
 		for j = 1, TrinketMenu.GetContainerNumSlots(i) do
-			if string.find(TrinketMenu.GetContainerItemLink(i, j) or "", name, 1, true) then
+			local containerItemLink = TrinketMenu.GetContainerItemLink(i, j) or ""
+			local containerItemName = GetItemInfo(containerItemLink)
+			if containerItemName == name then
 				return nil, i, j
 			end
 		end


### PR DESCRIPTION
current implementation causes an issue when you have an item in your bag with a similar name as a trinket you are trying to equip. Moving to exact matching fixes this problem.

![image](https://github.com/user-attachments/assets/02b3e015-2d74-4cfa-9161-50de775eaf3c) - item

![image](https://github.com/user-attachments/assets/0c4dd87c-233d-4cc5-8f8c-5004a5f2f025) - trinket

If you have the item first in your bags and try to equip the trinket it'll try to equip the item because its in your inventory first. Current workaround includes placing the item in your last bag slot so the matcher gets the trinket first.
