### PR TITLE
Fix issue with reenabling swap queue with alt+click

### DIFF
--- a/TrinketMenu.lua
+++ b/TrinketMenu.lua
@@ -818,6 +818,7 @@ function TrinketMenu.MainTrinket_OnClick(self, button, down)
 		TrinketMenu.ReflectQueueEnabled()
 		-- toggle queue
 		TrinketMenu.UpdateCombatQueue()
+		TrinketMenu.PeriodicQueueCheck()
 	else
 		TrinketMenu.ReflectTrinketUse(self:GetID())
 	end


### PR DESCRIPTION
This fixes a bug where the queue will not reenable when activated via alt+click. Problem can be reproduced by disabling the swap queue via alt+click, then activate the trinket and reenabling the queue later on via alt+click. It will not swap the trinkets. Workaround for this was to reenable the queue via the menu checkbox for the trinket slot.